### PR TITLE
feat: add RMS-based loudness normalization

### DIFF
--- a/Assets/Scripts/IO/AudioManager.cs
+++ b/Assets/Scripts/IO/AudioManager.cs
@@ -442,7 +442,7 @@ namespace MajdataPlay.IO
             }
         }
 
-        public AudioSampleWrap LoadMusic(string path, bool normalize = true, bool speedChange = false)
+        public AudioSampleWrap LoadMusic(string path, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             MajDebug.LogInfo($"Try creating channel from file: {path}");
             var backend = MajInstances.Settings.Audio.Backend;
@@ -456,10 +456,10 @@ namespace MajdataPlay.IO
                         break;
                     case SoundBackendOption.Asio:
                     case SoundBackendOption.Wasapi:
-                        sample = BassAudioSample.Create(path, BassGlobalMixer, normalize, speedChange);
+                        sample = BassAudioSample.Create(path, BassGlobalMixer, normalize, speedChange, cachedRmsDb);
                         break;
                     case SoundBackendOption.BassSimple:
-                        sample = BassSimpleAudioSample.Create(path, normalize, speedChange);
+                        sample = BassSimpleAudioSample.Create(path, normalize, speedChange, cachedRmsDb);
                         break;
                     default:
                         MajDebug.LogError("Backend not supported");
@@ -498,7 +498,7 @@ namespace MajdataPlay.IO
             MajDebug.LogInfo("Channel created");
             return sample;
         }
-        public async UniTask<AudioSampleWrap> LoadMusicAsync(string path, bool normalize = true, bool speedChange = false)
+        public async UniTask<AudioSampleWrap> LoadMusicAsync(string path, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             MajDebug.LogInfo($"Try creating channel from file: {path}");
             await UniTask.SwitchToThreadPool();
@@ -514,10 +514,10 @@ namespace MajdataPlay.IO
                         break;
                     case SoundBackendOption.Asio:
                     case SoundBackendOption.Wasapi:
-                        sample = await BassAudioSample.CreateAsync(path, BassGlobalMixer, normalize, speedChange);
+                        sample = await BassAudioSample.CreateAsync(path, BassGlobalMixer, normalize, speedChange, cachedRmsDb);
                         break;
                     case SoundBackendOption.BassSimple:
-                        sample = await BassSimpleAudioSample.CreateAsync(path, normalize, speedChange);
+                        sample = await BassSimpleAudioSample.CreateAsync(path, normalize, speedChange, cachedRmsDb);
                         break;
                     default:
                         MajDebug.LogError("Backend not supported");

--- a/Assets/Scripts/IO/Base/Audio/AudioSampleWrap.cs
+++ b/Assets/Scripts/IO/Base/Audio/AudioSampleWrap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +22,7 @@ namespace MajdataPlay.IO
         public abstract TimeSpan Length { get; }
         public abstract bool IsLoop { get; set; }
         public bool CanSeek { get; protected init; }
+        public float? MeasuredRmsDb { get; set; } = null;
 
         protected bool _isDisposed = false;
 

--- a/Assets/Scripts/IO/Base/Audio/BassAudioSample.cs
+++ b/Assets/Scripts/IO/Base/Audio/BassAudioSample.cs
@@ -229,7 +229,11 @@ namespace MajdataPlay.IO
 
             return new ValueTask(Task.CompletedTask);
         }
-        static BassAudioSample Create(byte[] data, int globalMixer, bool normalize, bool speedChange)
+        const double TARGET_RMS_DB = -14.0;
+        const double GAIN_MIN = 0.1;
+        const double GAIN_MAX = 4.0;
+
+        static BassAudioSample Create(byte[] data, int globalMixer, bool normalize, bool speedChange, float? cachedRmsDb = null)
         {
             var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var addr = handle.AddrOfPinnedObject();
@@ -244,10 +248,44 @@ namespace MajdataPlay.IO
                 }
                 Bass.ChannelSetAttribute(decode, ChannelAttribute.Buffer, 0);
 
-                //scan the peak here
                 var bytelength = Bass.ChannelGetLength(decode);
                 var gain = 1d;
-                if (normalize)
+                float? measuredRmsDb = null;
+                var useLoudnessNorm = MajInstances.Settings.Audio.LoudnessNormalization;
+
+                if (normalize && useLoudnessNorm && cachedRmsDb.HasValue)
+                {
+                    var rmsDb = (double)cachedRmsDb.Value;
+                    gain = Math.Pow(10, (TARGET_RMS_DB - rmsDb) / 20.0);
+                    gain = Math.Clamp(gain, GAIN_MIN, GAIN_MAX);
+                    measuredRmsDb = cachedRmsDb.Value;
+                    MajDebug.LogInfo($"[LoudnessNorm] Using cached RMS: {rmsDb:F2} dB, gain: {gain:F4}");
+                }
+                else if (normalize && useLoudnessNorm)
+                {
+                    double sumSquares = 0;
+                    int windowCount = 0;
+                    while (Bass.ChannelGetPosition(decode, PositionFlags.Decode | PositionFlags.Bytes) < bytelength)
+                    {
+                        var levels = Bass.ChannelGetLevel(decode, 1.0f, LevelRetrievalFlags.RMS | LevelRetrievalFlags.Mono);
+                        if (levels is not null && levels.Length > 0)
+                        {
+                            double rms = levels[0];
+                            sumSquares += rms * rms;
+                            windowCount++;
+                        }
+                    }
+                    if (windowCount > 0)
+                    {
+                        var avgRms = Math.Sqrt(sumSquares / windowCount);
+                        var rmsDb = 20.0 * Math.Log10(Math.Max(avgRms, 1e-10));
+                        gain = Math.Pow(10, (TARGET_RMS_DB - rmsDb) / 20.0);
+                        gain = Math.Clamp(gain, GAIN_MIN, GAIN_MAX);
+                        measuredRmsDb = (float)rmsDb;
+                        MajDebug.LogInfo($"[LoudnessNorm] Measured RMS: {rmsDb:F2} dB, target: {TARGET_RMS_DB:F2} dB, gain: {gain:F4}");
+                    }
+                }
+                else if (normalize)
                 {
                     double channelmax = 0;
                     while (Bass.ChannelGetPosition(decode, PositionFlags.Decode | PositionFlags.Bytes) < bytelength)
@@ -264,6 +302,7 @@ namespace MajdataPlay.IO
                 var sample = new BassAudioSample(decode, globalMixer, gain, speedChange)
                 {
                     CanSeek = true,
+                    MeasuredRmsDb = measuredRmsDb,
                 };
                 sample.Volume = 1;
 
@@ -279,17 +318,17 @@ namespace MajdataPlay.IO
                 throw;
             }
         }
-        public static BassAudioSample Create(string path, int globalMixer, bool normalize = true, bool speedChange = false)
+        public static BassAudioSample Create(string path, int globalMixer, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             var buf = File.ReadAllBytes(path);
 
-            return Create(buf, globalMixer, normalize, speedChange);
+            return Create(buf, globalMixer, normalize, speedChange, cachedRmsDb);
         }
-        public static async ValueTask<BassAudioSample> CreateAsync(string path, int globalMixer, bool normalize = true, bool speedChange = false)
+        public static async ValueTask<BassAudioSample> CreateAsync(string path, int globalMixer, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             var buf = await File.ReadAllBytesAsync(path);
 
-            return Create(buf, globalMixer, normalize, speedChange);
+            return Create(buf, globalMixer, normalize, speedChange, cachedRmsDb);
         }
         public static BassAudioSample CreateFromUri(Uri uri, int globalMixer)
         {

--- a/Assets/Scripts/IO/Base/Audio/BassSimpleAudioSample.cs
+++ b/Assets/Scripts/IO/Base/Audio/BassSimpleAudioSample.cs
@@ -216,7 +216,11 @@ namespace MajdataPlay.IO
             }
 #endif
         }
-        static BassSimpleAudioSample Create(byte[] data, bool normalize, bool speedChange)
+        const double TARGET_RMS_DB = -14.0;
+        const double GAIN_MIN = 0.1;
+        const double GAIN_MAX = 4.0;
+
+        static BassSimpleAudioSample Create(byte[] data, bool normalize, bool speedChange, float? cachedRmsDb = null)
         {
             var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var addr = handle.AddrOfPinnedObject();
@@ -227,10 +231,45 @@ namespace MajdataPlay.IO
                 stream = BassFx.TempoCreate(decode, BassFlags.Default);
                 Bass.LastError.EnsureSuccessStatusCode();
                 Bass.ChannelSetAttribute(stream, ChannelAttribute.Buffer, 0);
-                //scan the peak here
+
                 var bytelength = Bass.ChannelGetLength(decode);
                 var gain = 1d;
-                if (normalize)
+                float? measuredRmsDb = null;
+                var useLoudnessNorm = MajInstances.Settings.Audio.LoudnessNormalization;
+
+                if (normalize && useLoudnessNorm && cachedRmsDb.HasValue)
+                {
+                    var rmsDb = (double)cachedRmsDb.Value;
+                    gain = Math.Pow(10, (TARGET_RMS_DB - rmsDb) / 20.0);
+                    gain = Math.Clamp(gain, GAIN_MIN, GAIN_MAX);
+                    measuredRmsDb = cachedRmsDb.Value;
+                    MajDebug.LogInfo($"[LoudnessNorm] Using cached RMS: {rmsDb:F2} dB, gain: {gain:F4}");
+                }
+                else if (normalize && useLoudnessNorm)
+                {
+                    double sumSquares = 0;
+                    int windowCount = 0;
+                    while (Bass.ChannelGetPosition(decode, PositionFlags.Decode | PositionFlags.Bytes) < bytelength)
+                    {
+                        var levels = Bass.ChannelGetLevel(decode, 1.0f, LevelRetrievalFlags.RMS | LevelRetrievalFlags.Mono);
+                        if (levels is not null && levels.Length > 0)
+                        {
+                            double rms = levels[0];
+                            sumSquares += rms * rms;
+                            windowCount++;
+                        }
+                    }
+                    if (windowCount > 0)
+                    {
+                        var avgRms = Math.Sqrt(sumSquares / windowCount);
+                        var rmsDb = 20.0 * Math.Log10(Math.Max(avgRms, 1e-10));
+                        gain = Math.Pow(10, (TARGET_RMS_DB - rmsDb) / 20.0);
+                        gain = Math.Clamp(gain, GAIN_MIN, GAIN_MAX);
+                        measuredRmsDb = (float)rmsDb;
+                        MajDebug.LogInfo($"[LoudnessNorm] Measured RMS: {rmsDb:F2} dB, target: {TARGET_RMS_DB:F2} dB, gain: {gain:F4}");
+                    }
+                }
+                else if (normalize)
                 {
                     double channelmax = 0;
                     while (Bass.ChannelGetPosition(decode, PositionFlags.Decode | PositionFlags.Bytes) < bytelength)
@@ -247,6 +286,7 @@ namespace MajdataPlay.IO
                 var sample = new BassSimpleAudioSample(stream, gain, handle, speedChange)
                 {
                     CanSeek = true,
+                    MeasuredRmsDb = measuredRmsDb,
                 };
                 sample.Volume = 1;
                 sample._decode = decode;
@@ -262,17 +302,17 @@ namespace MajdataPlay.IO
                 throw;
             }
         }
-        public static BassSimpleAudioSample Create(string path, bool normalize = true, bool speedChange = false)
+        public static BassSimpleAudioSample Create(string path, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             var buf = File.ReadAllBytes(path);
 
-            return Create(buf, normalize, speedChange);
+            return Create(buf, normalize, speedChange, cachedRmsDb);
         }
-        public static async ValueTask<BassSimpleAudioSample> CreateAsync(string path, bool normalize = true, bool speedChange = false)
+        public static async ValueTask<BassSimpleAudioSample> CreateAsync(string path, bool normalize = true, bool speedChange = false, float? cachedRmsDb = null)
         {
             var buf = await File.ReadAllBytesAsync(path);
 
-            return Create(buf, normalize, speedChange);
+            return Create(buf, normalize, speedChange, cachedRmsDb);
         }
         public static BassSimpleAudioSample CreateFromUri(Uri uri)
         {

--- a/Assets/Scripts/Misc/Base/DataFormats/OnlineSongDetail.cs
+++ b/Assets/Scripts/Misc/Base/DataFormats/OnlineSongDetail.cs
@@ -534,7 +534,8 @@ namespace MajdataPlay
                         {
                             return AudioSampleWrap.Empty;
                         }
-                        var sampleWarp = await MajInstances.AudioManager.LoadMusicAsync(savePath, true, true);
+                        var cachedRmsDb = _chartSettings.MeasuredRmsDb;
+                        var sampleWarp = await MajInstances.AudioManager.LoadMusicAsync(savePath, true, true, cachedRmsDb);
                         if (sampleWarp.IsEmpty)
                         {
                             if (File.Exists(cacheFlagPath))
@@ -542,6 +543,10 @@ namespace MajdataPlay
                                 File.Delete(cacheFlagPath);
                             }
                             await DownloadFile(_trackUri, savePath, false, progress, token);
+                        }
+                        if (sampleWarp.MeasuredRmsDb.HasValue && sampleWarp.MeasuredRmsDb != cachedRmsDb)
+                        {
+                            _chartSettings.MeasuredRmsDb = sampleWarp.MeasuredRmsDb;
                         }
                         _audioTrackRef.SetTarget(sampleWarp);
 

--- a/Assets/Scripts/Misc/Base/DataFormats/SongDetail.cs
+++ b/Assets/Scripts/Misc/Base/DataFormats/SongDetail.cs
@@ -187,7 +187,12 @@ namespace MajdataPlay
                         return audioTrack;
                     }
                     progress?.Report(1);
-                    audioTrack = await MajInstances.AudioManager.LoadMusicAsync(_trackPath, true, true);
+                    var cachedRmsDb = _chartSettings.MeasuredRmsDb;
+                    audioTrack = await MajInstances.AudioManager.LoadMusicAsync(_trackPath, true, true, cachedRmsDb);
+                    if (audioTrack.MeasuredRmsDb.HasValue && audioTrack.MeasuredRmsDb != cachedRmsDb)
+                    {
+                        _chartSettings.MeasuredRmsDb = audioTrack.MeasuredRmsDb;
+                    }
                     _audioTrackRef.SetTarget(audioTrack);
                     return audioTrack;
                 }

--- a/Assets/Scripts/Misc/Settings/ChartSetting.cs
+++ b/Assets/Scripts/Misc/Settings/ChartSetting.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,5 +21,7 @@ namespace MajdataPlay.Settings
         [Range("-2", "2", HasMax = true, HasMin = true)]
         public float TrackVolumeOffset { get; set; } = 0f;
         public bool DisableVideoBG { get; set; } = false;
+        [HideInSettingUI, Preserve]
+        public float? MeasuredRmsDb { get; set; } = null;
     }
 }

--- a/Assets/Scripts/Misc/Settings/GameSetting.cs
+++ b/Assets/Scripts/Misc/Settings/GameSetting.cs
@@ -224,6 +224,8 @@ namespace MajdataPlay.Settings
 #endif
         
         public SoundBackendOption Backend { get; set; } = DEFAULT_SOUND_BACKEND;
+        
+        public bool LoudnessNormalization { get; set; } = false;
     }
     
     public class SFXVolume


### PR DESCRIPTION
Replace peak-amplitude normalization with RMS-based loudness normalization using BASS ChannelGetLevelEx with the RMS flag. When enabled, all songs are normalized to a -14 dB RMS target so perceived volume is consistent across tracks.

- Add LoudnessNormalization toggle to SoundOptions (default off)

- Add MeasuredRmsDb cache field to ChartSetting for persistence

- Implement RMS scan in BassAudioSample and BassSimpleAudioSample

- Pass cached RMS through AudioManager to skip re-measurement

- Wire cache read/write in SongDetail and OnlineSongDetail

Ref #259

---

Hi! 本 PR 实现了 #259 中讨论的 RMS-based loudness normalization，无新增依赖。但是在 merge 之前有几个设计问题想先确认：

**1. 替换还是保留 peak normalization？**
目前的实现保留了两种方式：原有的 peak normalization 仍为当前默认，RMS normalization 通过 `settings.json` > `Audio` 下的 `"LoudnessNormalization": true` 控制（默认关闭）。我们是让 RMS 替代旧的 peak normalization，还是两者并存，让玩家选择？（例如在游戏内的设置界面中添加对应选项）

**2. 默认行为**
如果两者并存，`LoudnessNormalization` 应该默认 `true` 还是 `false`？

**3. Settings UI 可见性**
目前这个 toggle 只能通过 `settings.json` 手动修改，因为 `SettingManager` 对 `Audio` 只暴露了 `Volume` 子菜单。需要在游戏内 settings UI 中加入这个选项吗？如果需要，放在哪里合适？

**4. 目标响度值**
当前使用 -14 dB RMS 作为 normalization target（参考主流串流平台标准）。是否需要换一个值，或者做成用户可调？

**测试结果**（使用同一首歌，ffmpeg 降低 10 dB 制作对照组）：
- 原曲：measured RMS = -11.84 dB，gain = 0.78x（衰减）
- -10 dB 副本：measured RMS = -21.83 dB，gain = 2.46x（增益）
<img width="849" height="406" alt="image" src="https://github.com/user-attachments/assets/04e7d746-0617-4458-ada4-33d5fdfad4b9" />


开启 normalization 后两首歌的感知音量基本一致。RMS 测量结果会缓存到 `ChartSetting`（内存变量，不会写入文件），从选曲界面进入歌曲后会跳过重复扫描。
