### PR TITLE
feat: Customizable mixing matrix

### DIFF
--- a/Assets/Scripts/IO/AudioManager.cs
+++ b/Assets/Scripts/IO/AudioManager.cs
@@ -622,175 +622,101 @@ namespace MajdataPlay.IO
             }
 #endif
         }
-        static void GenerateMixingMatrix(int chCount)
+        const int INPUT_CHANNELS = 2;   // Game output channel count, aka backend input channel count
+
+        static bool TryGetUserMatrix(int outputChCount, out float[,] userMatrix)
         {
-            //        var matrix = new float[8, 2]
-            //        {
-            //// Input      L   R
-            //            { 1f, 0f }, // LF
-            //            { 0f, 1f }, // RF
-            //            { 0f, 0f }, // Center
-            //            { 0f, 0f }, // LFE
-            //            { 0f, 0f }, // LR
-            //            { 0f, 0f }, // RR
-            //            { 0f, 0f }, // LR Center
-            //            { 0f, 0f }, // RR Center
-            //        };
-            // 3 channels      left - front, right - front, center.
-            // 4 channels      left - front, right - front, left - rear / side, right - rear / side.
-            // 6 channels(5.1) left - front, right - front, center, LFE, left - rear / side, right - rear / side.
-            // 8 channels(7.1) left - front, right - front, center, LFE, left - rear / side, right - rear / side, left - rear center, right - rear center.
+            var config = MajEnv.Settings.Audio.MixingMatrix.ByChannelCount;
+            string? key = outputChCount.ToString();
+            return config.TryGetValue(key, out userMatrix) || config.TryGetValue("*", out userMatrix);
+        }
 
-            // LFE = left
-            // Center = right
-
-            float[,] matrix;
-
-            var isForceMono = MajEnv.Settings.Audio.ForceMono;
-#if UNITY_ANDROID || UNITY_IOS
-            var volumeSettings = new
+        static bool ValidateMixingMatrix(float[,] matrix, int expectedOutputCh)
+        {
+            int matrixInputCh = matrix.GetLength(1);
+            int matrixOutputCh = matrix.GetLength(0);
+            if (matrixOutputCh == 0 || matrixInputCh != INPUT_CHANNELS || matrixOutputCh > expectedOutputCh)
             {
-                FrontVolume = 1f,
-                CenterAndLFEVolume = 1f,
-                SideVolume = 1f,
-                RearVolume = 1f
-            };
-#else
-            var volumeSettings = MajEnv.Settings.Audio.Channel;
-#endif
+                MajDebug.LogWarning($"[Audio] Mixing matrix shape: [{matrix.GetLength(0)}, {matrix.GetLength(1)}], expecting [{expectedOutputCh}, {INPUT_CHANNELS}]. Using fallback.");
+                return false;
+            }
+
+            for (int i = 0; i < matrixOutputCh; i++)
+            {
+                bool allZero = true;
+                for (int j = 0; j < INPUT_CHANNELS; j++)
+                {
+                    if (Math.Abs(matrix[i, j]) > 0.001f)
+                    {
+                        allZero = false;
+                        break;
+                    }
+                }
+                if (allZero)
+                {
+                    MajDebug.LogWarning($"[Audio] Output channel {i} is used but muted.");
+                }
+            }
+
+            return true;
+        }
+
+        static float[,] ExpandMatrix(float[,] matrix, int targetOutputCh)
+        {
+            int rows = matrix.GetLength(0);
+            if (rows >= targetOutputCh)
+            {
+                return matrix;
+            }
+
+            var expanded = new float[targetOutputCh, INPUT_CHANNELS];
+            for (int i = 0; i < rows; i++)
+            {
+                for (int j = 0; j < INPUT_CHANNELS; j++)
+                {
+                    expanded[i, j] = matrix[i, j];
+                }
+            }
+            return expanded;
+        }
+
+        static float[,] GetDefaultMatrix(int outputChCount, bool isForceMono)
+        {
             if (isForceMono)
             {
-                switch (chCount)
+                var matrix = new float[outputChCount, INPUT_CHANNELS];
+                for (int i = 0; i < outputChCount; i++)
                 {
-                    case 1:// Mono
-                        matrix = new float[1, 2]
-                        {
-                            { 0.5f, 0.5f }
-                        };
-                        break;
-                    case 2: // 2.0
-                        matrix = new float[2, 2]
-                        {
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f }
-                        };
-                        break;
-                    case 3: // 3.0
-                        matrix = new float[3, 2]
-                        {
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                        };
-                        break;
-                    case 4: // 4.0
-                        matrix = new float[4, 2]
-                        {
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                        };
-                        break;
-                    case 6: // 5.1
-                        matrix = new float[6, 2]
-                        {
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                        };
-                        break;
-                    case 8: // 7.1
-                        matrix = new float[8, 2]
-                        {
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                            { 0.5f, 0.5f },
-                        };
-                        break;
-                    default:
-                        matrix = new float[1, 2]
-                        {
-                            { 0.5f, 0.5f }
-                        };
-                        break;
+                    matrix[i, 0] = 0.5f;
+                    matrix[i, 1] = 0.5f;
                 }
+                return matrix;
+            }
+
+            return outputChCount switch
+            {
+                // [output_ch, input_ch]: row i = [L_weight, R_weight] for output channel i
+                1 => new float[1, 2] { { 0.5f, 0.5f } },
+                4 => new float[4, 2] { { 1f, 0f }, { 0f, 1f }, { 0.5f, 0.5f }, { 0.5f, 0.5f } },
+                6 => new float[6, 2] { { 1f, 0f }, { 0f, 1f }, { 0.5f, 0.5f }, { 0.5f, 0.5f }, { 0f, 0f }, { 0f, 0f } },
+                8 => new float[8, 2] { { 1f, 0f }, { 0f, 1f }, { 0.5f, 0.5f }, { 0.5f, 0.5f }, { 0f, 0f }, { 0f, 0f }, { 0f, 0f }, { 0f, 0f } },
+                _ => new float[2, 2] { { 1f, 0f }, { 0f, 1f } }
+            };
+        }
+
+        static void GenerateMixingMatrix(int outputChCount)
+        {
+            float[,] matrix;
+
+            if (TryGetUserMatrix(outputChCount, out var userMatrix) && ValidateMixingMatrix(userMatrix, outputChCount))
+            {
+                matrix = ExpandMatrix(userMatrix, outputChCount);
             }
             else
             {
-                switch (chCount)
-                {
-                    case 1:// Mono
-                        matrix = new float[1, 2]
-                        {
-                            { 0.5f, 0.5f }
-                        };
-                        break;
-                    case 2: // 2.0
-                        matrix = new float[2, 2]
-                        {
-                            { volumeSettings.FrontVolume, 0f },
-                            { 0f, volumeSettings.FrontVolume }
-                        };
-                        break;
-                    case 3: // 3.0
-                        matrix = new float[3, 2]
-                        {
-                            { volumeSettings.FrontVolume, 0f },
-                            { volumeSettings.CenterAndLFEVolume/2f, volumeSettings.CenterAndLFEVolume/2f },
-                            { 0f, volumeSettings.FrontVolume },
-                        };
-                        break;
-                    case 4: // 4.0
-                        matrix = new float[4, 2]
-                        {
-                            { volumeSettings.FrontVolume, 0f },
-                            { 0f, volumeSettings.FrontVolume },
-                            { volumeSettings.RearVolume, 0f },
-                            { 0f, volumeSettings.RearVolume },
-                        };
-                        break;
-                    case 6: // 5.1
-                        matrix = new float[6, 2]
-                        {
-                            { volumeSettings.FrontVolume, 0f },
-                            { 0f, volumeSettings.FrontVolume },
-                            { volumeSettings.CenterAndLFEVolume, 0f },
-                            { 0f, volumeSettings.CenterAndLFEVolume },
-                            { volumeSettings.SideVolume, 0f },
-                            { 0f, volumeSettings.SideVolume }
-                        };
-                        break;
-                    case 8: // 7.1
-                        matrix = new float[8, 2]
-                        {
-                            { volumeSettings.FrontVolume, 0f },
-                            { 0f, volumeSettings.FrontVolume },
-                            { volumeSettings.CenterAndLFEVolume, 0f },
-                            { 0f, volumeSettings.CenterAndLFEVolume },
-                            { volumeSettings.SideVolume, 0f },
-                            { 0f, volumeSettings.SideVolume },
-                            { volumeSettings.RearVolume, 0f },
-                            { 0f, volumeSettings.RearVolume },
-                        };
-                        break;
-                    default:
-                        matrix = new float[1, 2]
-                        {
-                            { 0.5f, 0.5f }
-                        };
-                        break;
-                }
+                MajDebug.LogWarning($"[Audio] Using default matrix.");
+                matrix = GetDefaultMatrix(outputChCount, MajEnv.Settings.Audio.ForceMono);
             }
-
 
             MixingMatrix = matrix;
         }

--- a/Assets/Scripts/Misc/Base/MajEnv.cs
+++ b/Assets/Scripts/Misc/Base/MajEnv.cs
@@ -9,6 +9,7 @@ using LibVLCSharp;
 using MajdataPlay.Buffers;
 using MajdataPlay.Collections;
 using MajdataPlay.Extensions;
+using MajdataPlay.Json;
 using MajdataPlay.Net;
 using MajdataPlay.Numerics;
 using MajdataPlay.Settings;
@@ -141,7 +142,8 @@ namespace MajdataPlay
             ObjectCreationHandling = ObjectCreationHandling.Replace,
             Converters =
             {
-                new StringEnumConverter()
+                new StringEnumConverter(),
+                new MixingMatrixConfigConverter()
             }
         };
 

--- a/Assets/Scripts/Misc/Json/JsonConverters/MixingMatrixConfigConverter.cs
+++ b/Assets/Scripts/Misc/Json/JsonConverters/MixingMatrixConfigConverter.cs
@@ -1,0 +1,79 @@
+using MajdataPlay.Settings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+#nullable enable
+
+namespace MajdataPlay.Json
+{
+    public class MixingMatrixConfigConverter : JsonConverter<MixingMatrixConfig>
+    {
+        const int INPUT_CHANNELS = 2;
+
+        public override MixingMatrixConfig? ReadJson(JsonReader reader, Type objectType, MixingMatrixConfig? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var config = new MixingMatrixConfig();
+            var obj = JObject.Load(reader);
+
+            foreach (var prop in obj.Properties())
+            {
+                var key = prop.Name;
+                if (prop.Value is not JArray array)
+                {
+                    continue;
+                }
+
+                int rowCount = array.Count;
+                if (rowCount == 0)
+                {
+                    continue;
+                }
+
+                var matrix = new float[rowCount, INPUT_CHANNELS];
+                for (int i = 0; i < rowCount; i++)
+                {
+                    if (array[i] is not JArray row)
+                    {
+                        continue;
+                    }
+                    for (int j = 0; j < Math.Min(row.Count, INPUT_CHANNELS); j++)
+                    {
+                        var val = row[j]?.Value<float>() ?? 0f;
+                        matrix[i, j] = Math.Clamp(val, -1f, 1f);
+                    }
+                }
+
+                config.ByChannelCount[key] = matrix;
+            }
+
+            return config;
+        }
+
+        public override void WriteJson(JsonWriter writer, MixingMatrixConfig? value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            foreach (var kvp in value!.ByChannelCount)
+            {
+                writer.WritePropertyName(kvp.Key);
+                writer.WriteStartArray();
+                var matrix = kvp.Value;
+                int rows = matrix.GetLength(0);
+                int cols = matrix.GetLength(1);
+                for (int i = 0; i < rows; i++)
+                {
+                    writer.WriteStartArray();
+                    for (int j = 0; j < cols; j++)
+                    {
+                        writer.WriteValue(matrix[i, j]);
+                    }
+                    writer.WriteEndArray();
+                }
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Assets/Scripts/Misc/Settings/GameSetting.cs
+++ b/Assets/Scripts/Misc/Settings/GameSetting.cs
@@ -230,10 +230,11 @@ namespace MajdataPlay.Settings
 #if !(UNITY_ANDROID || UNITY_IOS)
         
         public WasapiOptions Wasapi { get; set; } = new();
-        
+
         public AsioOptions Asio { get; set; } = new();
-        
-        public ChannelOptions Channel { get; set; } = new();
+
+        [HideInSettingUI]
+        public MixingMatrixConfig MixingMatrix { get; set; } = new();
 #else
         public MobileAudioOptions Mobile { get; set; } = new();
 #endif
@@ -653,18 +654,11 @@ namespace MajdataPlay.Settings
         public int E { get; set; }
     }
 
-    public class ChannelOptions
+    public class MixingMatrixConfig
     {
-        // Front (LF / RF)
-        // Rear (LR / RR)
-        // Side (LS / RS) (rear center)
-        // CenterAndLFE (LFE / Center)
-        public float FrontVolume { get; set; } = 1f;
-        public float CenterAndLFEVolume { get; set; } = 1f;
-        public float SideVolume { get; set; } = 1f;
-        public float RearVolume { get; set; } = 1f;
-
+        public Dictionary<string, float[,]> ByChannelCount { get; set; } = new();
     }
+
     public class AsioOptions
     {
         public int DeviceIndex { get; set; } = 0;


### PR DESCRIPTION
### Overview
Support user customizable mixing matrix in `settings.json`.

### Features
- Matching mixing matrix with **device output channel count**, or fall back wildcard `"*"`.
- Auto fill zeros.
- Priority: matched mixing matrix > `ForceMono` switch > default matrix

### Usage example
```jsonc
// settings.json
"Audio": {
  "MixingMatrix": {
    "22": [[1, 0], [0, 1], [], [0.5, 0], [0, 0.5]],
    "*": [[1, 1], [1, 1]]
  }
}
```

### Some concerns
- For now only works with ASIO and WASAPI.
- For WASAPI:
    - In unmodified `dev` branch, there's currently a bug causing all my USB interfaces being detected with 0 output channel. Need further investigation. ASIO is working as expected.
    - My internal sound card only has 2 outputs. Need to verify whether it works with internal sound cards with outputs more than 2.

### Manual testing
With mixing matrix above:
<img width="704" height="340" alt="5 out" src="https://github.com/user-attachments/assets/be1de312-3e51-40e1-bcab-68e433ed4043" />

With `ForceMono` switch on (and mixing matrix removed):
<img width="704" height="340" alt="ForceMono" src="https://github.com/user-attachments/assets/4104dee9-c346-404d-9e5b-cb03146a94ba" />