### PR TITLE
perf: 使用 SQLite 替换 JSON 存储成绩数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /settings.json
 /ModSettings.json
 /MajDatabase.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db
+/MajScores.db
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
 /[Mm]emoryCaptures/
@@ -95,3 +96,4 @@ out.log
 /ChartSetting.db
 /android-publish.keystore
 *.slnx
+machine_description.json

--- a/Assets/Scripts/Misc/Base/DataFormats/MaiScore.cs
+++ b/Assets/Scripts/Misc/Base/DataFormats/MaiScore.cs
@@ -17,7 +17,7 @@ namespace MajdataPlay
         public ChartLevel ChartLevel { get; init; } = ChartLevel.Easy;
         public string? Hash { get; init; } = null;
         public long PlayCount { get; set; } = 0;
-        public JudgeDetail? JudgeDeatil { get; set; } = null;
+        public JudgeDetail? JudgeDetail { get; set; } = null;
         public DateTime Timestamp { get; set; } = DateTime.MinValue;
         public ComboState ComboState { get; set; } = ComboState.None;
         public static MaiScore CreateFromResult(in GameResult result, ChartLevel level)
@@ -34,7 +34,7 @@ namespace MajdataPlay
             record.DXScore = result.DXScore;
             record.TotalDXScore = result.TotalDXScore;
 
-            record.JudgeDeatil = result.JudgeRecord;
+            record.JudgeDetail = result.JudgeRecord;
             record.Fast = result.Fast;
             record.Late = result.Late;
             record.ComboState = result.ComboState > record.ComboState ? result.ComboState : record.ComboState;

--- a/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs
+++ b/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs
@@ -1,0 +1,110 @@
+using MajdataPlay.Collections;
+using MajdataPlay.Scenes.Game;
+using Newtonsoft.Json;
+using SQLite;
+using System;
+
+#nullable enable
+namespace MajdataPlay
+{
+    [Table("MaiScores")]
+    public class MaiScoreDB
+    {
+        [PrimaryKey]
+        public string HashLevel { get; set; } = string.Empty;
+
+        [Indexed]
+        public string Hash { get; set; } = string.Empty;
+
+        public int ChartLevelInt { get; set; }
+
+        public double AccDX { get; set; }
+        public double AccClassic { get; set; }
+        public long DXScore { get; set; }
+        public long TotalDXScore { get; set; }
+        public long Fast { get; set; }
+        public long Late { get; set; }
+        public long PlayCount { get; set; }
+        public string? JudgeDetailJson { get; set; }
+        public long TimestampTicks { get; set; }
+        public int ComboStateInt { get; set; }
+
+        static readonly JsonSerializerSettings _jsonSettings = new()
+        {
+            Converters = new System.Collections.Generic.List<JsonConverter>
+            {
+                new Json.JudgeDetailConverter(),
+                new Json.JudgeInfoConverter(),
+            }
+        };
+
+        public static string MakeKey(string hash, ChartLevel level) => $"{hash}|{(int)level}";
+        public static string MakeKey(string hash, int levelInt) => $"{hash}|{levelInt}";
+
+        public MaiScore ToMaiScore()
+        {
+            JudgeDetail? judgeDetail = null;
+            if (!string.IsNullOrEmpty(JudgeDetailJson))
+            {
+                try
+                {
+                    judgeDetail = JsonConvert.DeserializeObject<JudgeDetail>(JudgeDetailJson, _jsonSettings);
+                }
+                catch
+                {
+                    judgeDetail = JudgeDetail.Empty;
+                }
+            }
+
+            return new MaiScore()
+            {
+                Hash = Hash,
+                ChartLevel = (ChartLevel)ChartLevelInt,
+                Acc = new Accurate { DX = AccDX, Classic = AccClassic },
+                DXScore = DXScore,
+                TotalDXScore = TotalDXScore,
+                Fast = Fast,
+                Late = Late,
+                PlayCount = PlayCount,
+                JudgeDeatil = judgeDetail ?? JudgeDetail.Empty,
+                Timestamp = new DateTime(TimestampTicks, DateTimeKind.Local),
+                ComboState = (ComboState)ComboStateInt,
+            };
+        }
+
+        public static MaiScoreDB FromMaiScore(MaiScore score)
+        {
+            string? judgeJson = null;
+            if (score.JudgeDeatil is not null)
+            {
+                try
+                {
+                    judgeJson = JsonConvert.SerializeObject(score.JudgeDeatil, _jsonSettings);
+                }
+                catch
+                {
+                    judgeJson = null;
+                }
+            }
+
+            var hash = score.Hash ?? string.Empty;
+
+            return new MaiScoreDB()
+            {
+                HashLevel = MakeKey(hash, score.ChartLevel),
+                Hash = hash,
+                ChartLevelInt = (int)score.ChartLevel,
+                AccDX = score.Acc.DX,
+                AccClassic = score.Acc.Classic,
+                DXScore = score.DXScore,
+                TotalDXScore = score.TotalDXScore,
+                Fast = score.Fast,
+                Late = score.Late,
+                PlayCount = score.PlayCount,
+                JudgeDetailJson = judgeJson,
+                TimestampTicks = score.Timestamp.Ticks,
+                ComboStateInt = (int)score.ComboState,
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs
+++ b/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs
@@ -66,7 +66,7 @@ namespace MajdataPlay
                 Fast = Fast,
                 Late = Late,
                 PlayCount = PlayCount,
-                JudgeDeatil = judgeDetail ?? JudgeDetail.Empty,
+                JudgeDetail = judgeDetail ?? JudgeDetail.Empty,
                 Timestamp = new DateTime(TimestampTicks, DateTimeKind.Local),
                 ComboState = (ComboState)ComboStateInt,
             };
@@ -75,11 +75,11 @@ namespace MajdataPlay
         public static MaiScoreDB FromMaiScore(MaiScore score)
         {
             string? judgeJson = null;
-            if (score.JudgeDeatil is not null)
+            if (score.JudgeDetail is not null)
             {
                 try
                 {
-                    judgeJson = JsonConvert.SerializeObject(score.JudgeDeatil, _jsonSettings);
+                    judgeJson = JsonConvert.SerializeObject(score.JudgeDetail, _jsonSettings);
                 }
                 catch
                 {

--- a/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs.meta
+++ b/Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25110046384bfb84f90d11c353abfb12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Misc/Base/MajEnv.cs
+++ b/Assets/Scripts/Misc/Base/MajEnv.cs
@@ -98,6 +98,7 @@ namespace MajdataPlay
         public static string LogsPath { get; private set; } = string.Empty;
         public static string LangPath { get; private set; } = string.Empty;
         public static string ScoreDBPath { get; private set; } = string.Empty;
+        public static string LegacyScoreDBPath { get; private set; } = string.Empty;
         public static string LogPath { get; private set; } = string.Empty;
         public static string RecordOutputsPath { get; private set; } = string.Empty;
         [Preserve] public static Sprite EmptySongCover { get; }
@@ -263,8 +264,9 @@ namespace MajdataPlay
             SkinPath = Path.Combine(RootPath, "Skins");
             LogsPath = Path.Combine(RootPath, $"Logs");
             LangPath = Path.Combine(AssetsPath, "Langs");
-            ScoreDBPath = Path.Combine(RootPath,
+            LegacyScoreDBPath = Path.Combine(RootPath,
                 "MajDatabase.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db.db");
+            ScoreDBPath = Path.Combine(RootPath, "MajScores.db");
             LogPath = Path.Combine(LogsPath, $"MajPlayRuntime.log");
             RecordOutputsPath = Path.Combine(RootPath, "RecordOutputs");
         }

--- a/Assets/Scripts/Misc/Base/ScoreManager.cs
+++ b/Assets/Scripts/Misc/Base/ScoreManager.cs
@@ -1,7 +1,8 @@
-﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using MajdataPlay.Json;
 using MajdataPlay.Utils;
 using Newtonsoft.Json;
+using SQLite;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,16 +23,17 @@ namespace MajdataPlay
 
         readonly static Dictionary<string, SongScores> _buckets = new();
 
-        readonly static JsonSerializer _serializer = JsonSerializer.Create(new()
+        static SQLiteAsyncConnection? _db;
+
+        readonly static JsonSerializerSettings _jsonReadSettings = new()
         {
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            DefaultValueHandling = DefaultValueHandling.Populate,
+            ObjectCreationHandling = ObjectCreationHandling.Replace,
             Converters = new List<JsonConverter>
             {
                 new JudgeDetailConverter(),
                 new JudgeInfoConverter(),
             }
-        });
+        };
 
         internal static async UniTask InitAsync()
         {
@@ -42,110 +44,114 @@ namespace MajdataPlay
             _isInited = true;
             try
             {
-                var path = MajEnv.ScoreDBPath;
+                var dbPath = MajEnv.ScoreDBPath;
+                _db = new SQLiteAsyncConnection(dbPath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex);
 
-                if (!File.Exists(path))
+                await _db.CreateTableAsync<MaiScoreDB>();
+
+                // Migrate from legacy JSON file
+                var legacyPath = MajEnv.LegacyScoreDBPath;
+                if (File.Exists(legacyPath))
                 {
-                    var songScores = _buckets.Select(x => x.Value);
-                    var scores = Array.Empty<MaiScore>()
-                                      .Concat(songScores.Select(x => x.Easy))
-                                      .Concat(songScores.Select(x => x.Basic))
-                                      .Concat(songScores.Select(x => x.Advance))
-                                      .Concat(songScores.Select(x => x.Expert))
-                                      .Concat(songScores.Select(x => x.Master))
-                                      .Concat(songScores.Select(x => x.ReMaster))
-                                      .Concat(songScores.Select(x => x.UTAGE))
-                                      .ToArray();
-                    var json = await Serializer.Json.SerializeAsync(scores);
-                    await File.WriteAllTextAsync(path, json);
-                    return;
+                    var migrated = await MigrateFromJsonAsync(legacyPath);
+                    if (migrated)
+                    {
+                        try
+                        {
+                            File.Delete(legacyPath);
+                            MajDebug.LogInfo("Migrated scores from legacy JSON to SQLite, old file deleted.");
+                        }
+                        catch (Exception ex)
+                        {
+                            MajDebug.LogError($"Failed to delete legacy score file: {ex.Message}");
+                        }
+                    }
                 }
-                using var storageStream = File.OpenRead(path);
-                List<MaiScore>? result = await Serializer.Json.DeserializeAsync<List<MaiScore>>(storageStream, _serializer);
-                //shoud do some warning here, or all score will be lost and overwirtten
-                var grouped = result.GroupBy(x => x.Hash);
-                var dicts = grouped.Select(x => (x.Key ,x.ToDictionary(x => x.ChartLevel, x => x)));
-                foreach(var (hash, dict) in dicts)
+
+                // Load from SQLite
+                var rows = await _db.QueryAsync<MaiScoreDB>("SELECT * FROM MaiScores WHERE PlayCount > 0");
+                var grouped = rows.Select(x => x.ToMaiScore()).GroupBy(x => x.Hash);
+                foreach (var group in grouped)
                 {
-                    if(string.IsNullOrEmpty(hash))
+                    var hash = group.Key;
+                    if (string.IsNullOrEmpty(hash))
                     {
                         continue;
                     }
-                    if(!dict.TryGetValue(ChartLevel.Easy,out var easy))
-                    {
-                        easy = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.Basic, out var basic))
-                    {
-                        basic = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.Advance, out var advance))
-                    {
-                        advance = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.Expert, out var expert))
-                    {
-                        expert = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.Master, out var master))
-                    {
-                        master = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.ReMaster, out var remas))
-                    {
-                        remas = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
-                    if (!dict.TryGetValue(ChartLevel.UTAGE, out var utage))
-                    {
-                        utage = new MaiScore()
-                        {
-                            Hash = hash,
-                            PlayCount = 0
-                        };
-                    }
+                    var dict = group.ToDictionary(x => x.ChartLevel, x => x);
 
                     var scores = new SongScores()
                     {
-                        Easy = easy,
-                        Basic = basic,
-                        Advance = advance,
-                        Expert = expert,
-                        Master = master,
-                        ReMaster = remas,
-                        UTAGE = utage
+                        Easy = GetOrCreate(dict, hash, ChartLevel.Easy),
+                        Basic = GetOrCreate(dict, hash, ChartLevel.Basic),
+                        Advance = GetOrCreate(dict, hash, ChartLevel.Advance),
+                        Expert = GetOrCreate(dict, hash, ChartLevel.Expert),
+                        Master = GetOrCreate(dict, hash, ChartLevel.Master),
+                        ReMaster = GetOrCreate(dict, hash, ChartLevel.ReMaster),
+                        UTAGE = GetOrCreate(dict, hash, ChartLevel.UTAGE),
                     };
-                    _buckets.Add(hash!, scores);
+                    _buckets.Add(hash, scores);
                 }
+            }
+            catch(Exception e)
+            {
+                MajDebug.LogError(e);
             }
             finally
             {
                 await UniTask.Yield();
             }
         }
+
+        static MaiScore GetOrCreate(Dictionary<ChartLevel, MaiScore> dict, string hash, ChartLevel level)
+        {
+            if (dict.TryGetValue(level, out var score))
+            {
+                return score;
+            }
+            return new MaiScore()
+            {
+                Hash = hash,
+                ChartLevel = level,
+                PlayCount = 0,
+            };
+        }
+
+        static async Task<bool> MigrateFromJsonAsync(string legacyPath)
+        {
+            try
+            {
+                var json = await File.ReadAllTextAsync(legacyPath);
+                var scores = JsonConvert.DeserializeObject<List<MaiScore>>(json, _jsonReadSettings);
+                if (scores is null || scores.Count == 0)
+                {
+                    return true; // nothing to migrate
+                }
+
+                var dbRows = new List<MaiScoreDB>(scores.Count);
+                foreach (var score in scores)
+                {
+                    if (string.IsNullOrEmpty(score.Hash) || score.PlayCount == 0)
+                    {
+                        continue;
+                    }
+                    dbRows.Add(MaiScoreDB.FromMaiScore(score));
+                }
+
+                if (dbRows.Count > 0 && _db is not null)
+                {
+                    await _db.InsertAllAsync(dbRows, runInTransaction: true);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MajDebug.LogError($"Failed to migrate legacy scores: {ex.Message}");
+                return false;
+            }
+        }
+
         public static MaiScore GetScore(ISongDetail song, ChartLevel level)
         {
             var hash = song.Hash;
@@ -207,23 +213,15 @@ namespace MajdataPlay
                 record.Timestamp = DateTime.Now;
                 record.PlayCount++;
 
-                using var stream = File.Create(MajEnv.ScoreDBPath);
-                var songScores = _buckets.Select(x => x.Value);
-                var scores = Array.Empty<MaiScore>()
-                                  .Concat(songScores.Select(x => x.Easy))
-                                  .Concat(songScores.Select(x => x.Basic))
-                                  .Concat(songScores.Select(x => x.Advance))
-                                  .Concat(songScores.Select(x => x.Expert))
-                                  .Concat(songScores.Select(x => x.Master))
-                                  .Concat(songScores.Select(x => x.ReMaster))
-                                  .Concat(songScores.Select(x => x.UTAGE))
-                                  .Where(x => x.PlayCount != 0)
-                                  .ToArray();
-                await Serializer.Json.SerializeAsync(stream, scores, _serializer);
+                if (_db is not null)
+                {
+                    var dbRow = MaiScoreDB.FromMaiScore(record);
+                    await _db.InsertOrReplaceAsync(dbRow);
+                }
 
                 return true;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 MajDebug.LogError(ex);
                 return false;
@@ -244,13 +242,13 @@ namespace MajdataPlay
                 for (var i = 0; i < scores.Length; i++)
                 {
                     var score = scores[i];
-                    if(!_onlineBuckets.TryGetValue(score.Hash, out var scoreRecord))
+                    if (!_onlineBuckets.TryGetValue(score.Hash, out var scoreRecord))
                     {
                         scoreRecord = SongScores.Create(score.Hash);
                         _onlineBuckets.Add(score.Hash, scoreRecord);
                     }
                     var maiScore = default(MaiScore);
-                    switch(score.ChartLevel)
+                    switch (score.ChartLevel)
                     {
                         case ChartLevel.Easy:
                             maiScore = scoreRecord.Easy;
@@ -329,7 +327,7 @@ namespace MajdataPlay
             }
             finally
             {
-                if(isLocked)
+                if (isLocked)
                 {
                     @lock.Exit();
                 }

--- a/Assets/Scripts/Misc/Base/ScoreManager.cs
+++ b/Assets/Scripts/Misc/Base/ScoreManager.cs
@@ -206,7 +206,7 @@ namespace MajdataPlay
                 record.DXScore = result.DXScore > record.DXScore ? result.DXScore : record.DXScore;
                 record.TotalDXScore = result.TotalDXScore;
 
-                record.JudgeDeatil = result.JudgeRecord;
+                record.JudgeDetail = result.JudgeRecord;
                 record.Fast = result.Fast;
                 record.Late = result.Late;
                 record.ComboState = result.ComboState > record.ComboState ? result.ComboState : record.ComboState;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.gilzoide.sqlite-net": "https://github.com/gilzoide/unity-sqlite-net.git#1.3.2",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.unity.collab-proxy": "2.7.1",
     "com.unity.feature.2d": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.gilzoide.sqlite-net": {
+      "version": "https://github.com/gilzoide/unity-sqlite-net.git#1.3.2",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "08248bd5884d8eb932a837aa56d4ff456daf913f"
+    },
     "com.github-glitchenzo.nugetforunity": {
       "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
       "depth": 0,


### PR DESCRIPTION
## 改动摘要

将成绩存储从 JSON 文件迁移到 SQLite 数据库，解决游戏异常关闭时 JSON 全量覆写导致数据丢失的问题。

##  改动文件

### 新增

- Assets/Scripts/Misc/Base/DataFormats/MaiScoreDB.cs — SQLite 数据表映射类，MaiScore 与数据库行之间的 DTO 转换

### 修改

- Assets/Scripts/Misc/Base/MajEnv.cs — ScoreDBPath 指向新的 MajScores.db；保留旧路径 LegacyScoreDBPath 用于自动迁移
 - Assets/Scripts/Misc/Base/ScoreManager.cs — 所有持久化 I/O 从 JSON 全量读写改为 SQLite 行级操作
- .gitignore — 新增 /MajScores.db
- Packages/manifest.json — 新增 com.gilzoide.sqlite-net 依赖
- MajScors类中的typo

##  自动迁移

首次启动时自动检测旧的 MajDatabase.db.db... 文件，将其中的成绩全部导入MajScores.db，成功后删除旧文件。迁移失败则保留旧文件不删。

##  核心改进

- 写入原子性：SaveScore 从全量覆写 JSON（~200行数据全部重写）变为 InsertOrReplaceAsync 单行 upsert，SQLite事务保证操作失败自动回滚
- 崩溃安全：不会再出现写 JSON 中途崩溃导致全部成绩丢失的问题