### PR TITLE
fix: use runtime API endpoint for user profile

### DIFF
--- a/Assets/Scripts/Scenes/List/ListManager.cs
+++ b/Assets/Scripts/Scenes/List/ListManager.cs
@@ -162,15 +162,10 @@ namespace MajdataPlay.Scenes.List
         void DisplayUserInfo()
         {
             //TODO: display multiple endpoints
-            var apiendpoint = MajEnv.Settings.Online.ApiEndpoints.FirstOrDefault();
-            if (apiendpoint is not null)
-            {
-                _userProfileDisplayer.DisplayUserInfo(apiendpoint);
-            }
-            else
-            {
-                _userProfileDisplayer.gameObject.SetActive(false);
-            }
+            var apiEndpoint = MajEnv.ApiEndpoints.FirstOrDefault(x => x.RuntimeConfig.IsLoggedIn)
+                           ?? MajEnv.ApiEndpoints.FirstOrDefault();
+
+            _userProfileDisplayer.DisplayUserInfo(apiEndpoint);
         }
 
         async UniTaskVoid InitializeCoverListAsync()

--- a/Assets/Scripts/Scenes/List/UserInfoDisplayer.cs
+++ b/Assets/Scripts/Scenes/List/UserInfoDisplayer.cs
@@ -40,20 +40,22 @@ namespace MajdataPlay
             Refresh();
         }
 
-        public void DisplayUserInfo(ApiEndpoint apiEndpoint)
+        public void DisplayUserInfo(ApiEndpoint? apiEndpoint)
         {
             _currentApiEndpoint = apiEndpoint;
+            gameObject.SetActive(apiEndpoint is not null);
+
+            if (apiEndpoint is not null)
+            {
+                Refresh();
+            }
         }
 
         public void DisplayFromSong(ISongDetail song)
         {
-            if (song is not OnlineSongDetail)
-            {
-                gameObject.SetActive(false);
-                return;
-            }
-            var serverInfo = ((OnlineSongDetail)song).ServerInfo;
-            DisplayUserInfo(serverInfo);     
+            DisplayUserInfo(song is OnlineSongDetail onlineSong
+                ? onlineSong.ServerInfo
+                : null);
         }
 
         void Refresh()


### PR DESCRIPTION
Select the active endpoint from MajEnv.ApiEndpoints and let UserInfoDisplayer own its visibility state.

fix #302 